### PR TITLE
Provide a more ergonomic way of setting arguments and working directory

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -15,4 +15,4 @@ jobs:
       - name: Run Kani
         uses: ./ # Uses the action in the root directory
         with:
-          command: cd tests/cargo-kani/simple-lib && cargo-kani
+          working-directory: tests/cargo-kani/simple-lib

--- a/action.yml
+++ b/action.yml
@@ -19,9 +19,9 @@ inputs:
     required: false
     default: '.'
   args:
-    description: 'Arguments to pass to kani.  Default: --workspace'
+    description: 'Arguments to pass to kani.'
     required: false
-    default: '--workspace'
+    default: ''
 
 runs:
   using: "composite"
@@ -29,13 +29,13 @@ runs:
     - name: Install Kani
       shell: bash
       run: |
-        export KANI_VERSION="0.13.0"; \
-        cargo install --version $KANI_VERSION --locked kani-verifier; \
+        export KANI_VERSION="0.13.0";
+        cargo install --version $KANI_VERSION --locked kani-verifier;
         cargo-kani setup;
 
     - name: Run Kani
       shell: bash
       run: | 
-        cd ${{ inputs.working-directory }}; \
+        cd ${{ inputs.working-directory }};
         ${{ inputs.command }} ${{ inputs.args }}
 

--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,15 @@ inputs:
   command:
     description: 'Command to run.'
     required: false
-    default: 'cargo-kani --workspace'
+    default: 'cargo-kani'
+  working-directory:
+    description: 'Directory to run kani on.'
+    required: false
+    default: '.'
+  args:
+    description: 'Arguments to pass to kani.  Default: --workspace'
+    required: false
+    default: '--workspace'
 
 runs:
   using: "composite"
@@ -28,5 +36,6 @@ runs:
     - name: Run Kani
       shell: bash
       run: | 
-        ${{ inputs.command }}
+        cd ${{ inputs.working-directory }}; \
+        ${{ inputs.command }} ${{ inputs.args }}
 


### PR DESCRIPTION
### Description of changes: 

Currently, overriding the command is all or nothing.
Looking at use-cases for the repo, it looks like we want a way to set "working-directory" and "args" but seldom want to override `cargo-kani`.
Making these seperate args makes integrating the action easier customerside

### Resolved issues:

Resolves #ISSUE-NUMBER

### Related RFC:

<!--
Link to the Tracking RFC issue if this work implements part of an RFC.
-->
Optional #ISSUE-NUMBER.

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested?

* Is this a refactor change?

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
