### PR TITLE
Install updated toolchain to the one from the kani release

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,13 @@ inputs:
 runs:
   using: "composite"
   steps:
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1.0.7
+        id: toolchain
+        with:
+          toolchain: stable
+          override: true
+
     - name: Install Kani
       shell: bash
       run: |

--- a/action.yml
+++ b/action.yml
@@ -26,12 +26,12 @@ inputs:
 runs:
   using: "composite"
   steps:
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1.0.7
-        id: toolchain
-        with:
-          toolchain: stable
-          override: true
+      # - name: Install Rust
+      #   uses: actions-rs/toolchain@v1.0.7
+      #   id: toolchain
+      #   with:
+      #     toolchain: stable
+      #     override: true
 
     - name: Install Kani
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -30,6 +30,7 @@ runs:
       uses: actions-rs/toolchain@v1.0.7
       with:
         # From https://github.com/model-checking/kani/blob/kani-0.13.0/rust-toolchain.toml
+        # Should be updated every time we update the version to keep in sync.
         # This should be automated https://github.com/model-checking/kani-github-action/issues/9
         toolchain: nightly-2022-10-11
         override: true

--- a/action.yml
+++ b/action.yml
@@ -26,12 +26,11 @@ inputs:
 runs:
   using: "composite"
   steps:
-      # - name: Install Rust
-      #   uses: actions-rs/toolchain@v1.0.7
-      #   id: toolchain
-      #   with:
-      #     toolchain: stable
-      #     override: true
+    - name: Install Rust
+      uses: actions-rs/toolchain@v1.0.7
+      with:
+        toolchain: stable
+        override: true
 
     - name: Install Kani
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,7 @@ runs:
     - name: Install Rust
       uses: actions-rs/toolchain@v1.0.7
       with:
-        toolchain: stable
+        toolchain: nightly-2022-10-25
         override: true
 
     - name: Install Kani

--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,9 @@ runs:
     - name: Install Rust
       uses: actions-rs/toolchain@v1.0.7
       with:
-        toolchain: nightly-2022-10-25
+        # From https://github.com/model-checking/kani/blob/kani-0.13.0/rust-toolchain.toml
+        # This should be automated https://github.com/model-checking/kani-github-action/issues/9
+        toolchain: nightly-2022-10-11
         override: true
 
     - name: Install Kani


### PR DESCRIPTION
### Description of changes: 

Currently, we rely on the default toolchain on the machine. If its too old, that causes problems like here: https://github.com/aws/s2n-quic/actions/runs/3347681915/jobs/5545938616

### Resolved issues:

Resolves #ISSUE-NUMBER

### Related RFC:

<!--
Link to the Tracking RFC issue if this work implements part of an RFC.
-->
Optional #ISSUE-NUMBER.

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested?

* Is this a refactor change?

### Checklist
- [ ] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [ ] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
