### PR TITLE
Update kani to v0.14.1

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -47,3 +47,4 @@ runs:
       run: |
         cd ${{ inputs.working-directory }};
         ${{ inputs.command }} ${{ inputs.args }}
+

--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,7 @@ runs:
     - name: Install Rust
       uses: actions-rs/toolchain@v1.0.7
       with:
-        # From https://github.com/model-checking/kani/blob/kani-0.14.0/rust-toolchain.toml
+        # From https://github.com/model-checking/kani/blob/kani-0.14.1/rust-toolchain.toml
         # Should be updated every time we update the version to keep in sync.
         # This should be automated https://github.com/model-checking/kani-github-action/issues/9
         toolchain: nightly-2022-10-24
@@ -38,7 +38,7 @@ runs:
     - name: Install Kani
       shell: bash
       run: |
-        export KANI_VERSION="0.14.0";
+        export KANI_VERSION="0.14.1";
         cargo install --version $KANI_VERSION --locked kani-verifier;
         cargo-kani setup;
 
@@ -47,4 +47,3 @@ runs:
       run: |
         cd ${{ inputs.working-directory }};
         ${{ inputs.command }} ${{ inputs.args }}
-


### PR DESCRIPTION
### Description of changes: 

Update Kani to it's latest patch which adds installation support for m1 (`aarch64-apple-darwin`) platforms.

### Call-outs:

Will fold this into kani-github-action v0.14; not release a new version or patch.

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
