### PR TITLE
Bump Kani version to `0.17.0`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,7 @@ runs:
     - name: Install Rust
       uses: actions-rs/toolchain@v1.0.7
       with:
-        # From https://github.com/model-checking/kani/blob/kani-0.16.0/rust-toolchain.toml
+        # From https://github.com/model-checking/kani/blob/kani-0.17.0/rust-toolchain.toml
         # Should be updated every time we update the version to keep in sync.
         # This should be automated https://github.com/model-checking/kani-github-action/issues/9
         toolchain: nightly-2022-11-20
@@ -38,7 +38,7 @@ runs:
     - name: Install Kani
       shell: bash
       run: |
-        export KANI_VERSION="0.16.0";
+        export KANI_VERSION="0.17.0";
         cargo install --version $KANI_VERSION --locked kani-verifier;
         cargo-kani setup;
 


### PR DESCRIPTION
### Description of changes: 

Update Kani version. Toolchain update will be skipped this week.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
