### PR TITLE
Avoid cloning kani submodules and fix `enable-propproof` flag

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -47,7 +47,7 @@ runs:
         cargo-kani setup;
 
     - name: Install PropProof
-      if: ${{ inputs.enable-propproof }}
+      if: ${{ inputs.enable-propproof == 'true' }}
       uses: actions/checkout@v3
       with:
         repository: model-checking/kani
@@ -56,7 +56,7 @@ runs:
         submodules: true
 
     - name: Add PropProof to config
-      if: ${{ inputs.enable-propproof }}
+      if: ${{ inputs.enable-propproof == 'true' }}
       shell: bash
       run: |
         echo "paths = [\"$GITHUB_WORKSPACE/propproof\"]" > $HOME/.cargo/config.toml

--- a/action.yml
+++ b/action.yml
@@ -53,7 +53,7 @@ runs:
         export PROPPROOF_PATH=$HOME/propproof
         git clone https://github.com/model-checking/kani \
         --branch features/proptest $PROPPROOF_PATH || true
-        git -C $PROPPROOF_PATH submodule update --init --recursive
+        git -C $PROPPROOF_PATH submodule update --init
         echo "paths = [\"$PROPPROOF_PATH\"]" > $HOME/.cargo/config.toml
       # || true is used to handle cases where the propproof folder is cached.
 

--- a/action.yml
+++ b/action.yml
@@ -59,7 +59,7 @@ runs:
       if: ${{ inputs.enable-propproof }}
       shell: bash
       run: |
-        echo "paths = [\"${{ GITHUB_WORKSPACE }}/propproof\"]" > $HOME/.cargo/config.toml
+        echo "paths = [\"$GITHUB_WORKSPACE/propproof\"]" > $HOME/.cargo/config.toml
 
     - name: Run Kani
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -48,14 +48,15 @@ runs:
 
     - name: Install PropProof
       if: ${{ inputs.enable-propproof }}
+      uses: actions/checkout@v3
+      with:
+        repository: model-checking/kani
+        ref: features/proptest
+        path: propproof
+        submodules: true
       shell: bash
       run: |
-        export PROPPROOF_PATH=$HOME/propproof
-        git clone https://github.com/model-checking/kani \
-        --branch features/proptest $PROPPROOF_PATH || true
-        git -C $PROPPROOF_PATH submodule update --init
-        echo "paths = [\"$PROPPROOF_PATH\"]" > $HOME/.cargo/config.toml
-      # || true is used to handle cases where the propproof folder is cached.
+        echo "paths = [\"${{ GITHUB_WORKSPACE }}/propproof\"]" > $HOME/.cargo/config.toml
 
     - name: Run Kani
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -54,6 +54,9 @@ runs:
         ref: features/proptest
         path: propproof
         submodules: true
+
+    - name: Add PropProof to config
+      if: ${{ inputs.enable-propproof }}
       shell: bash
       run: |
         echo "paths = [\"${{ GITHUB_WORKSPACE }}/propproof\"]" > $HOME/.cargo/config.toml


### PR DESCRIPTION
### Description of changes: 

As part of installing `PropProof`, the GitHub action currently clones the Kani repo (the proptest branch) and initializes its submodules recursively. This unnecessarily brings in submodules used for development, e.g. `s2n-quic`, `nomicon`, `firecracker`, etc. This PR removes the `--recursive` option to avoid bringing in those submodules.

This PR also fixes the `enable-propproof` input, which was always being evaluated to true, thus executing the PropProof step regardless of the input value.

### Resolved issues:

Resolves #25 

### Related RFC:

<!--
Link to the Tracking RFC issue if this work implements part of an RFC.
-->

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? Current tests

* Is this a refactor change? No

### Checklist
- [X] Each commit message has a non-empty body, explaining why the change was made
- [X] Methods or procedures are documented
- [X] Regression or unit tests are included, or existing tests cover the modified code
- [X] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
