### PR TITLE
Install stable rust toolchain

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -32,12 +32,6 @@ runs:
   steps:
     - name: Install Rust
       uses: actions-rs/toolchain@v1.0.7
-      with:
-        # From https://github.com/model-checking/kani/blob/kani-0.21.0/rust-toolchain.toml
-        # Should be updated every time we update the version to keep in sync.
-        # This should be automated https://github.com/model-checking/kani-github-action/issues/9
-        toolchain: nightly-2022-12-11
-        override: true
 
     - name: Install Kani
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,8 @@ runs:
   steps:
     - name: Install Rust
       uses: actions-rs/toolchain@v1.0.7
+      with:
+        toolchain: stable
 
     - name: Install Kani
       shell: bash


### PR DESCRIPTION
### Description of changes: 

The GitHub action currently requires updating the rust toolchain to install with every new release of Kani (as opposed to just updating the version of Kani). This shouldn't be necessary as Kani installs the required toolchain as part of its setup.

### Resolved issues:

Resolves #9 

### Related RFC:

<!--
Link to the Tracking RFC issue if this work implements part of an RFC.
-->
Optional #ISSUE-NUMBER.

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

### Testing:

* How is this change tested? Existing tests

* Is this a refactor change? No

### Checklist
- [X] Each commit message has a non-empty body, explaining why the change was made
- [X] Methods or procedures are documented
- [X] Regression or unit tests are included, or existing tests cover the modified code
- [X] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
