### PR TITLE
Bump version to 0.26.0

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -38,7 +38,7 @@ runs:
     - name: Install Kani
       shell: bash
       run: |
-        export KANI_VERSION="0.25.0";
+        export KANI_VERSION="0.26.0";
         cargo install --version $KANI_VERSION --locked kani-verifier;
         cargo-kani setup;
 


### PR DESCRIPTION
Update action to use Kani version 0.26.0

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
