### PR TITLE
Replaces actions-rs/toolchain with dtolnay/rust-toolchain

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -31,9 +31,7 @@ runs:
   using: "composite"
   steps:
     - name: Install Rust
-      uses: actions-rs/toolchain@v1.0.7
-      with:
-        toolchain: stable
+      uses: dtolnay/rust-toolchain@stable
 
     - name: Install Kani
       shell: bash


### PR DESCRIPTION
### Description of changes: 

Replaces actions-rs/toolchain with dtolnay/rust-toolchain to setup rust. As actions-rs/toolchain is unmaintained, it causes a node version warning.

### Testing:

* How is this change tested? CI

* Is this a refactor change? No

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [x] Methods or procedures are documented
- [x] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
