### PR TITLE
Decouple `kani` version from `kani-github-action` version

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -17,19 +17,18 @@ jobs:
         id: set_error
         run: |
           output=$(./src/install-kani.sh "0.47.0")
-          echo "action_state=$output" >> $GITHUB_ENV
         continue-on-error: true  # Continue to the next steps even if this job fails
 
       - name: Check for Expected Error with invalid version
         id: check_error
         run: |
-          printf '%s\n' "$action_state"
+          echo $output
 
       - name: Run Kani with older version
         uses: ./ # Uses the action in the root directory
         with:
           working-directory: tests/cargo-kani/simple-lib
-          kani-version: 0.33.0
+          kani-version: '0.33.0'
       - name: Run Kani
         uses: ./ # Uses the action in the root directory
         with:

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -21,6 +21,11 @@ jobs:
           kani-version: '0.47.0'
         continue-on-error: true  # Continue to the next steps even if this job fails
 
+      - name: Dump steps context
+        env:
+          STEPS_CONTEXT: ${{ toJson(steps) }}
+        run: echo "$STEPS_CONTEXT"
+
       - name: Check for Expected Error with invalid version
         id: check_error
         run: |

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -17,7 +17,7 @@ jobs:
         uses: ./ # Uses the action in the root directory
         with:
           working-directory: tests/cargo-kani/simple-lib
-          kani-version: 'l.33.1'
+          kani-version: '0.47.0'
         continue-on-error: true  # Continue to the next steps even if this job fails
 
       - name: Check for Expected Error with invalid version

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -25,7 +25,7 @@ jobs:
         id: check_error
         run: |
           # Check if the error output contains the expected error substring
-          if echo "${{ steps.set_error.outputs.stderr }}" | grep -q "Could not install Kani. Please check if the provided version is correct"; then
+          if echo "${{ steps.set_error.outputs.stdout }}" | grep -q "Could not install Kani. Please check if the provided version is correct"; then
             echo "Error message contains the expected substring."
           else
             echo "Error message does not contain the expected substring."

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Check for Expected Error with invalid version
         run: |
           # Check if the error output contains the expected error substring
-          if echo "${{ steps.run-kani-with-invalid-version.outputs }}" | grep -q "Could not install Kani. Please check if the provided version is correct"; then
+          if echo "${{ steps.run-kani-with-invalid-version.outputs.stderr }}" | grep -q "Could not install Kani. Please check if the provided version is correct"; then
             echo "Error message contains the expected substring."
           else
             echo "Error message does not contain the expected substring."

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -12,15 +12,15 @@ jobs:
       # you must check out the repository
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Run Kani
-        uses: ./ # Uses the action in the root directory
-        with:
-          working-directory: tests/cargo-kani/simple-lib
       - name: Run Kani with older version
         uses: ./ # Uses the action in the root directory
         with:
           working-directory: tests/cargo-kani/simple-lib
           kani-version: 0.33.0
+      - name: Run Kani
+        uses: ./ # Uses the action in the root directory
+        with:
+          working-directory: tests/cargo-kani/simple-lib
       - name: Test ProfProof within Kani Action
         uses: ./
         with:

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -18,18 +18,55 @@ jobs:
         uses: ./
         with:
           working-directory: tests/cargo-kani/simple-lib
-          kani-version: '0.47.0'
-        continue-on-error: true  # Continue to the next steps even if this job fails
+          kani-version: '0.1.10'
+        continue-on-error: true
+
+      - name: Ensure "Run Kani with invalid version" fails
+        id: get_error
+        run: |
+          # Check the outcome of "Run Kani with invalid version"
+          if [[ "${{ steps.set_error.outcome }}" == "failure" ]]; then
+            echo "Running Kani with invalid version "0.1.10" failed."
+          else
+            echo "::error::Running Kani with invalid version succeeded incorrectly or was skipped."
+            exit 1
+          fi
 
       - name: Run Kani with older version
         uses: ./ # Uses the action in the root directory
         with:
           working-directory: tests/cargo-kani/simple-lib
           kani-version: '0.33.0'
-      - name: Run Kani
+
+      - name: Test "Run Kani with older version"
+        run: |
+          installed_version=$(kani --version | awk '{print $2}')
+          expected_version='0.33.0'
+
+          if [[ "$installed_version" == "$expected_version" ]]; then
+            echo "The installed version ($installed_version) matches the expected version ($expected_version)."
+          else
+            echo "::error::The installed version ($installed_version) does not match the expected version ($expected_version)."
+            exit 1
+          fi
+
+      - name: Run Kani with latest version
         uses: ./ # Uses the action in the root directory
         with:
           working-directory: tests/cargo-kani/simple-lib
+
+      - name: Test "Run Kani with latest version"
+        run: |
+          installed_version=$(kani --version | awk '{print $2}')
+          expected_version=$(cargo search kani-verifier | grep -m 1 "kani" | awk '{print $3}' | sed 's/"//g')
+
+          if [[ "$installed_version" == "$expected_version" ]]; then
+            echo "The installed version ($installed_version) matches the latest version ($expected_version)"
+          else
+            echo "::error::The installed version ($installed_version) does not match the latest version ($expected_version)."
+            exit 1
+          fi
+
       - name: Test ProfProof within Kani Action
         uses: ./
         with:

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -17,20 +17,13 @@ jobs:
         id: set_error
         run: |
           output=$(./src/install-kani.sh "0.47.0")
-          echo $output
           echo "action_state=$output" >> $GITHUB_ENV
         continue-on-error: true  # Continue to the next steps even if this job fails
 
       - name: Check for Expected Error with invalid version
         id: check_error
         run: |
-          # Check if the error output contains the expected error substring
-          if echo "${action_state}" | grep -q "Could not install Kani. Please check if the provided version is correct"; then
-            echo "Error message contains the expected substring."
-          else
-            echo "Error message does not contain the expected substring."
-            exit 1  # Fail the job
-          fi
+          printf '%s\n' "$action_state"
 
       - name: Run Kani with older version
         uses: ./ # Uses the action in the root directory

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -16,6 +16,11 @@ jobs:
         uses: ./ # Uses the action in the root directory
         with:
           working-directory: tests/cargo-kani/simple-lib
+      - name: Run Kani with older version
+        uses: ./ # Uses the action in the root directory
+        with:
+          working-directory: tests/cargo-kani/simple-lib
+          kani-version: 0.33.0
       - name: Test ProfProof within Kani Action
         uses: ./
         with:

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -15,14 +15,11 @@ jobs:
 
       - name: Run Kani with invalid version
         id: set_error
-        run: |
-          output=$(./src/install-kani.sh "0.47.0")
+        uses: ./
+        with:
+          working-directory: tests/cargo-kani/simple-lib
+          kani-version: '0.47.0'
         continue-on-error: true  # Continue to the next steps even if this job fails
-
-      - name: Check for Expected Error with invalid version
-        id: check_error
-        run: |
-          echo $output
 
       - name: Run Kani with older version
         uses: ./ # Uses the action in the root directory

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Check for Expected Error with invalid version
         run: |
           # Check if the error output contains the expected error substring
-          if echo "${{ steps.run-and-check.outputs.invalid_value }}" | grep -q "Could not install Kani."; then
+          if echo "${{ steps.run-and-check.outputs.invalid_value }}" | grep -q "could not find `kani-verifier` in registry `crates-io` with version `=0.47.0`"; then
             echo "Error message contains the expected substring."
           else
             echo "Error message does not contain the expected substring."

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Check for Expected Error with invalid version
         run: |
           # Check if the error output contains the expected error substring
-          if echo "${{ steps.run-kani-with-invalid-version.outputs }}" | grep -q "could not find `kani-verifier` in registry `crates-io` with version `=0.47.0`"; then
+          if echo "${{ steps.run-kani-with-invalid-version.outputs }}" | grep -q "Could not install Kani. Please check if the provided version is correct"; then
             echo "Error message contains the expected substring."
           else
             echo "Error message does not contain the expected substring."

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -14,6 +14,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Run Kani with invalid version
+        id: set_error
         uses: ./ # Uses the action in the root directory
         with:
           working-directory: tests/cargo-kani/simple-lib
@@ -21,9 +22,10 @@ jobs:
         continue-on-error: true  # Continue to the next steps even if this job fails
 
       - name: Check for Expected Error with invalid version
+        id: check_error
         run: |
           # Check if the error output contains the expected error substring
-          if echo "${{ steps.run-kani-with-invalid-version.outputs.stderr }}" | grep -q "Could not install Kani. Please check if the provided version is correct"; then
+          if echo "${{ steps.set_error.outputs.stderr }}" | grep -q "Could not install Kani. Please check if the provided version is correct"; then
             echo "Error message contains the expected substring."
           else
             echo "Error message does not contain the expected substring."

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -17,14 +17,15 @@ jobs:
         id: set_error
         run: |
           output=$(./src/install-kani.sh "0.47.0")
-          echo "ACTION_OUTPUT=$output" >> $GITHUB_ENV
+          echo $output
+          echo "action_state=$output" >> $GITHUB_ENV
         continue-on-error: true  # Continue to the next steps even if this job fails
 
       - name: Check for Expected Error with invalid version
         id: check_error
         run: |
           # Check if the error output contains the expected error substring
-          if echo "$ACTION_OUTPUT" | grep -q "Could not install Kani. Please check if the provided version is correct"; then
+          if echo "${action_state}" | grep -q "Could not install Kani. Please check if the provided version is correct"; then
             echo "Error message contains the expected substring."
           else
             echo "Error message does not contain the expected substring."

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Check for Expected Error with invalid version
         run: |
           # Check if the error output contains the expected error substring
-          if echo "${{ steps.run-and-check.outputs.invalid_value }}" | grep -q "could not find `kani-verifier` in registry `crates-io` with version `=0.47.0`"; then
+          if echo "${{ steps.run-kani-with-invalid-version.outputs }}" | grep -q "could not find `kani-verifier` in registry `crates-io` with version `=0.47.0`"; then
             echo "Error message contains the expected substring."
           else
             echo "Error message does not contain the expected substring."

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -15,22 +15,16 @@ jobs:
 
       - name: Run Kani with invalid version
         id: set_error
-        uses: ./ # Uses the action in the root directory
-        with:
-          working-directory: tests/cargo-kani/simple-lib
-          kani-version: '0.47.0'
+        run: |
+          output=$(./src/install-kani.sh "0.47.0")
+          echo "ACTION_OUTPUT=$output" >> $GITHUB_ENV
         continue-on-error: true  # Continue to the next steps even if this job fails
-
-      - name: Dump steps context
-        env:
-          STEPS_CONTEXT: ${{ toJson(steps) }}
-        run: echo "$STEPS_CONTEXT"
 
       - name: Check for Expected Error with invalid version
         id: check_error
         run: |
           # Check if the error output contains the expected error substring
-          if echo "${{ steps.set_error.outputs.stdout }}" | grep -q "Could not install Kani. Please check if the provided version is correct"; then
+          if echo "$ACTION_OUTPUT" | grep -q "Could not install Kani. Please check if the provided version is correct"; then
             echo "Error message contains the expected substring."
           else
             echo "Error message does not contain the expected substring."

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -12,6 +12,24 @@ jobs:
       # you must check out the repository
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Run Kani with invalid version
+        uses: ./ # Uses the action in the root directory
+        with:
+          working-directory: tests/cargo-kani/simple-lib
+          kani-version: 'l.33.1'
+        continue-on-error: true  # Continue to the next steps even if this job fails
+
+      - name: Check for Expected Error with invalid version
+        run: |
+          # Check if the error output contains the expected error substring
+          if echo "${{ steps.run-and-check.outputs.invalid_value }}" | grep -q "Could not install Kani."; then
+            echo "Error message contains the expected substring."
+          else
+            echo "Error message does not contain the expected substring."
+            exit 1  # Fail the job
+          fi
+
       - name: Run Kani with older version
         uses: ./ # Uses the action in the root directory
         with:

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ If omitted, the latest version of `Kani` hosted on [`Kani's crates.io page`](htt
 
 `enable-propproof`
 
-- **Description**: Experimental feature that allows Kani to verify proptest harnesses using the PropProof feature.
+- **Description**: Experimental feature that allows Kani to verify [proptest harnesses](https://proptest-rs.github.io/proptest/proptest/index.html) using the PropProof feature.
 - **Default**: `false`
 - **Usage**: If set to `true`, Kani will enable the experimental PropProof feature for verifying proptest harnesses.
 

--- a/README.md
+++ b/README.md
@@ -41,9 +41,12 @@ If omitted, the latest version of `Kani` hosted on [`Kani's crates.io page`](htt
 
 ## Example usage in a workflow YAML file:
 
-Here are a few examples of workflow YAML files for the Kani Github Action
+Here are a few examples of workflow YAML files for the Kani Github Action:
 
-#### Example 1: Default config which uses the latest version of kani to run `cargo-kani` on project in current directory
+#### Example 1: Default configuration
+
+Default config which uses the latest version of Kani to run `cargo-kani` on project in current directory.
+
 ```yaml
 jobs:
   kani:
@@ -53,7 +56,10 @@ jobs:
         uses: model-checking/kani-github-action@v1.0
 ```
 
-#### Example 2: Use a specific version of kani, version `0.35.0`, to run `cargo-kani`  on a project
+#### Example 2: Use pinned version of Kani
+
+Use a specific version of Kani, version `0.35.0`, to run `cargo-kani`  on a project.
+
 ```yaml
 jobs:
   kani:
@@ -67,7 +73,10 @@ jobs:
           working-directory: './path/to/project'
 ```
 
-#### Example 3: Use pinned version of kani, version `0.35.0`, to run `cargo-kani --tests` on a project with propproof harnesses.
+#### Example 3: Run Kani with args
+
+Use latest version of Kani, to run `cargo-kani --tests` on a project with `propproof` harnesses.
+
 ```yaml
 jobs:
   kani:
@@ -76,9 +85,6 @@ jobs:
       - name: Run Kani
         uses: model-checking/kani-github-action@v1.0
         with:
-          kani-version: '0.35.0'
-          command: 'cargo-kani'
-          working-directory: './path/to/project'
           args: '--tests'
           enable-propproof: true
 ```

--- a/README.md
+++ b/README.md
@@ -10,44 +10,40 @@ The following parameters can be used to configure and customize the behavior of 
 
 `kani-version`
 
-- **Description**: Specifies the Kani version number to use.
-- **Default**: 'latest'
-- **Usage**: You can provide a specific version of Kani to use. [Cargo's version specific format is expected for specific versions](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html).
+- **Description**: The Kani version to use.
+- **Default**: `latest`
+- **Usage**: `latest` or `x.y.z` to mention which version Kani to use. [Cargo's version specific format is expected for specific versions](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html).
 If omitted, the latest version of `Kani` hosted on [`Kani's crates.io page`](https://crates.io/crates/kani-verifier) will be installed and used.
 
 `command`
 
-- **Description**: Specifies the command to run Kani.
-- **Default**: 'cargo-kani'
-- **Usage**: You can set a custom command to run Kani. For example, this allows you to use a different binary or script for Kani, if needed.
+- **Description**: The command to run Kani.
+- **Default**: `cargo-kani`
+- **Usage**: `cargo-kani` or `kani` or custom path to a `kani` binary. Subcommands need to be passed to the `args` field.
 
 `working-directory`
 
-- **Description**: Specifies the directory in which Kani should be run.
-- **Default**: '.'
-- **Usage**: Kani will be executed within this directory.
+- **Description**: The directory in which Kani should be run.
+- **Default**: `'.'`
+- **Usage**: `/path/to/project` or `.`
 
 `args`
 
-- **Description**: Specifies additional arguments to pass to Kani.
-- **Default**: ''
-- **Usage**: You can provide any additional command-line arguments to Kani using this parameter. These arguments will be appended to the Kani command.
+- **Description**: Additional arguments to pass to Kani.
+- **Default**: `''`
+- **Usage**: These arguments or subcommands will be appended to the Kani command.
 
 `enable-propproof`
 
 - **Description**: Experimental feature that allows Kani to verify proptest harnesses using the PropProof feature.
-- **Default**: false
+- **Default**: `false`
 - **Usage**: If set to `true`, Kani will enable the experimental PropProof feature for verifying proptest harnesses.
-
-## Kani-version default behavior
-
-Please note that since providing `kani-version` is optional, if the user doesn't provide the version, the action will install the latest version of `Kani` on `crates.io`.
 
 ## Example usage in a workflow YAML file:
 
 Here are a few examples of workflow YAML files for the Kani Github Action
 
-#### Default config which uses the latest version of kani on project
+#### Example 1: Default config which uses the latest version of kani to run `cargo-kani` on project in current directory
 ```yaml
 jobs:
   kani:
@@ -55,12 +51,9 @@ jobs:
     steps:
       - name: Run Kani
         uses: model-checking/kani-github-action@v1.0
-        with:
-          command: 'cargo-kani'
-          working-directory: './path/to/project'
 ```
 
-#### Use a specific version of kani, version `0.35.0` on project
+#### Example 2: Use a specific version of kani, version `0.35.0`, to run `cargo-kani`  on a project
 ```yaml
 jobs:
   kani:
@@ -74,7 +67,7 @@ jobs:
           working-directory: './path/to/project'
 ```
 
-#### Use pinned version of kani, version `0.35.0` on project with `--tests`
+#### Example 3: Use pinned version of kani, version `0.35.0`, to run `cargo-kani --tests` on a project with propproof harnesses.
 ```yaml
 jobs:
   kani:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,63 @@
 
 This repository provides a GitHub Action for running the [Kani Rust Verifier](https://github.com/model-checking/kani) in CI.
 
+## GitHub Action Parameters
+
+The following parameters can be used to configure and customize the behavior of this GitHub Action:
+
+### `kani-version` (optional)
+
+- **Description**: Specifies the Kani version number to use.
+- **Default**: 'latest'
+- **Usage**: You can provide a specific version of Kani to use. If omitted, the latest version will be installed and used.
+
+### `command` (optional)
+
+- **Description**: Specifies the command to run Kani.
+- **Default**: 'cargo-kani'
+- **Usage**: You can set a custom command to run Kani. For example, this allows you to use a different binary or script for Kani, if needed.
+
+### `working-directory` (optional)
+
+- **Description**: Specifies the directory in which Kani should be run.
+- **Default**: '.'
+- **Usage**: Kani will be executed within this directory.
+
+### `args` (optional)
+
+- **Description**: Specifies additional arguments to pass to Kani.
+- **Default**: ''
+- **Usage**: You can provide any additional command-line arguments to Kani using this parameter. These arguments will be appended to the Kani command.
+
+### `enable-propproof` (optional)
+
+- **Description**: Experimental feature that allows Kani to verify proptest harnesses using the PropProof feature.
+- **Default**: false
+- **Usage**: If set to `true`, Kani will enable the experimental PropProof feature for verifying proptest harnesses.
+
+### Kani-version default behavior
+
+Please note that since providing `kani-version` is optional, if the user doesn't provide the version, the action will install the latest version of `Kani` on `crates.io`.
+
+### Example usage in a workflow YAML file:
+
+Here is an example of a workflow YAML file for the Kani Github Action
+
+```yaml
+jobs:
+  kani:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run Kani
+        uses: model-checking/kani-github-action@v0.37
+        with:
+          kani-version: '0.35.0'
+          command: 'cargo-kani'
+          working-directory: './path/to/project'
+          args: '--tests'
+          enable-propproof: true
+
+
 ## Security
 
 See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.
@@ -10,4 +67,3 @@ See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more inform
 
 This code is distributed under the terms of both the MIT license and the Apache License (Version 2.0).
 See [LICENSE-APACHE](LICENSE-APACHE) and [LICENSE-MIT](LICENSE-MIT) for details.
-

--- a/README.md
+++ b/README.md
@@ -6,41 +6,43 @@ This repository provides a GitHub Action for running the [Kani Rust Verifier](ht
 
 The following parameters can be used to configure and customize the behavior of this GitHub Action:
 
-`kani-version` (optional)
+NOTE: All the fields provided are optional and have default behaviors when not specified.
+
+`kani-version`
 
 - **Description**: Specifies the Kani version number to use.
 - **Default**: 'latest'
 - **Usage**: You can provide a specific version of Kani to use. If omitted, the latest version will be installed and used.
 
-`command` (optional)
+`command`
 
 - **Description**: Specifies the command to run Kani.
 - **Default**: 'cargo-kani'
 - **Usage**: You can set a custom command to run Kani. For example, this allows you to use a different binary or script for Kani, if needed.
 
-`working-directory` (optional)
+`working-directory`
 
 - **Description**: Specifies the directory in which Kani should be run.
 - **Default**: '.'
 - **Usage**: Kani will be executed within this directory.
 
-`args` (optional)
+`args`
 
 - **Description**: Specifies additional arguments to pass to Kani.
 - **Default**: ''
 - **Usage**: You can provide any additional command-line arguments to Kani using this parameter. These arguments will be appended to the Kani command.
 
-`enable-propproof` (optional)
+`enable-propproof`
 
 - **Description**: Experimental feature that allows Kani to verify proptest harnesses using the PropProof feature.
 - **Default**: false
 - **Usage**: If set to `true`, Kani will enable the experimental PropProof feature for verifying proptest harnesses.
 
-### Kani-version default behavior
+## Kani-version default behavior
 
 Please note that since providing `kani-version` is optional, if the user doesn't provide the version, the action will install the latest version of `Kani` on `crates.io`.
 
-### Example usage in a workflow YAML file:
+## Example usage in a workflow YAML file:
 
 Here is an example of a workflow YAML file for the Kani Github Action
 

--- a/README.md
+++ b/README.md
@@ -6,31 +6,31 @@ This repository provides a GitHub Action for running the [Kani Rust Verifier](ht
 
 The following parameters can be used to configure and customize the behavior of this GitHub Action:
 
-### `kani-version` (optional)
+`kani-version` (optional)
 
 - **Description**: Specifies the Kani version number to use.
 - **Default**: 'latest'
 - **Usage**: You can provide a specific version of Kani to use. If omitted, the latest version will be installed and used.
 
-### `command` (optional)
+`command` (optional)
 
 - **Description**: Specifies the command to run Kani.
 - **Default**: 'cargo-kani'
 - **Usage**: You can set a custom command to run Kani. For example, this allows you to use a different binary or script for Kani, if needed.
 
-### `working-directory` (optional)
+`working-directory` (optional)
 
 - **Description**: Specifies the directory in which Kani should be run.
 - **Default**: '.'
 - **Usage**: Kani will be executed within this directory.
 
-### `args` (optional)
+`args` (optional)
 
 - **Description**: Specifies additional arguments to pass to Kani.
 - **Default**: ''
 - **Usage**: You can provide any additional command-line arguments to Kani using this parameter. These arguments will be appended to the Kani command.
 
-### `enable-propproof` (optional)
+`enable-propproof` (optional)
 
 - **Description**: Experimental feature that allows Kani to verify proptest harnesses using the PropProof feature.
 - **Default**: false
@@ -57,7 +57,7 @@ jobs:
           working-directory: './path/to/project'
           args: '--tests'
           enable-propproof: true
-
+```
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ NOTE: All the fields provided are optional and have default behaviors when not s
 
 - **Description**: Specifies the Kani version number to use.
 - **Default**: 'latest'
-- **Usage**: You can provide a specific version of Kani to use. If omitted, the latest version will be installed and used.
+- **Example-pinned-version**: `'0.33.0'`
+- **Usage**: You can provide a specific version of Kani to use. [Cargo's version specific format is expected for specific versions](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html).
+If omitted, the latest version of `Kani` hosted on [`Kani's crates.io page`](https://crates.io/crates/kani-verifier) will be installed and used.
 
 `command`
 

--- a/README.md
+++ b/README.md
@@ -2,17 +2,16 @@
 
 This repository provides a GitHub Action for running the [Kani Rust Verifier](https://github.com/model-checking/kani) in CI.
 
-## GitHub Action Parameters
+## Kani GitHub Action Parameters
 
 The following parameters can be used to configure and customize the behavior of this GitHub Action:
 
-NOTE: All the fields provided are optional and have default behaviors when not specified.
+**NOTE**: All the fields provided are optional and have default behaviors when not specified.
 
 `kani-version`
 
 - **Description**: Specifies the Kani version number to use.
 - **Default**: 'latest'
-- **Example-pinned-version**: `'0.33.0'`
 - **Usage**: You can provide a specific version of Kani to use. [Cargo's version specific format is expected for specific versions](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html).
 If omitted, the latest version of `Kani` hosted on [`Kani's crates.io page`](https://crates.io/crates/kani-verifier) will be installed and used.
 
@@ -46,15 +45,43 @@ Please note that since providing `kani-version` is optional, if the user doesn't
 
 ## Example usage in a workflow YAML file:
 
-Here is an example of a workflow YAML file for the Kani Github Action
+Here are a few examples of workflow YAML files for the Kani Github Action
 
+#### Default config which uses the latest version of kani on project
 ```yaml
 jobs:
   kani:
     runs-on: ubuntu-latest
     steps:
       - name: Run Kani
-        uses: model-checking/kani-github-action@v0.37
+        uses: model-checking/kani-github-action@v1.0
+        with:
+          command: 'cargo-kani'
+          working-directory: './path/to/project'
+```
+
+#### Use a specific version of kani, version `0.35.0` on project
+```yaml
+jobs:
+  kani:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run Kani
+        uses: model-checking/kani-github-action@v1.0
+        with:
+          kani-version: '0.35.0'
+          command: 'cargo-kani'
+          working-directory: './path/to/project'
+```
+
+#### Use pinned version of kani, version `0.35.0` on project with `--tests`
+```yaml
+jobs:
+  kani:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run Kani
+        uses: model-checking/kani-github-action@v1.0
         with:
           kani-version: '0.35.0'
           command: 'cargo-kani'

--- a/action.yml
+++ b/action.yml
@@ -40,10 +40,6 @@ runs:
     - name: Install Kani
       run: ${{ github.action_path }}/src/install-kani.sh ${{ inputs.kani-version }}
       shell: bash
-      run: |
-        export KANI_VERSION="0.37.0";
-        cargo install --version $KANI_VERSION --locked kani-verifier;
-        cargo-kani setup;
 
     - name: Install PropProof
       if: ${{ inputs.enable-propproof == 'true' }}

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,10 @@ branding:
   color: 'orange'
 
 inputs:
+  kani-version:
+    description: 'Kani Version number'
+    required: false
+    default: 'latest'
   command:
     description: 'Command to run.'
     required: false
@@ -34,11 +38,8 @@ runs:
       uses: dtolnay/rust-toolchain@stable
 
     - name: Install Kani
+      run: ${{ github.action_path }}/src/install-kani.sh ${{ inputs.kani-version }}
       shell: bash
-      run: |
-        export KANI_VERSION="0.35.0";
-        cargo install --version $KANI_VERSION --locked kani-verifier;
-        cargo-kani setup;
 
     - name: Install PropProof
       if: ${{ inputs.enable-propproof == 'true' }}

--- a/src/install-kani.sh
+++ b/src/install-kani.sh
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 # If version is latest, install directly from cargo
-echo $1;
 if [ "$1" == "latest" ]; then
     cargo install --locked kani-verifier;
 else

--- a/src/install-kani.sh
+++ b/src/install-kani.sh
@@ -11,7 +11,9 @@ else
 fi
 
 # Check exit status for error handling
-if [ $? -ne O ]; then
+if [ $? -eq O ]; then
+    echo "Installed Kani $VERSION successfully"
+else
     echo "::error::Could not install Kani. Please check if the provided version is correct"
     exit 1
 fi

--- a/src/install-kani.sh
+++ b/src/install-kani.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Copyright Kani Contributors
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+# If version is latest, install directly from cargo
+echo $1;
+if [ "$1" == "latest" ]; then
+    cargo install --locked kani-verifier;
+else
+    VERSION=$1
+    cargo install --version $VERSION --locked kani-verifier;
+fi
+
+# Check exit status for error handling
+if [ $? -ne O ]; then
+    echo "Error installing Kani. Please check if the provided version is correct"
+    exit 1
+fi
+
+# Setup kani in ci
+cargo-kani setup;

--- a/src/install-kani.sh
+++ b/src/install-kani.sh
@@ -12,9 +12,26 @@ fi
 
 # Check exit status for error handling
 if [ $? -ne O ]; then
-    echo "Error installing Kani. Please check if the provided version is correct"
+    echo "::error::Could not install Kani. Please check if the provided version is correct"
     exit 1
 fi
 
 # Setup kani in ci
 cargo-kani setup;
+
+# Get the current installed version of kani and check it against the latest version
+installed_version=$(kani --version | awk '{print $2}')
+
+if [ $? -eq 0 ]; then
+    if [ "$1" == "latest" ]; then
+        # Cargo search returns version number as string
+        requested_version=$(cargo search kani-verifier | grep -m 1 "^kani-verifier " | awk '{print $3}')
+    else
+        requested_version=$1
+    fi
+
+    if ["$installed_version" != "$requested_version"]; then
+        echo "::error::The version of Kani installed was different than the one requested"
+        exit 1
+    fi
+fi

--- a/src/install-kani.sh
+++ b/src/install-kani.sh
@@ -11,7 +11,7 @@ else
 fi
 
 # Check exit status for error handling
-if [$? -eq O]; then
+if [ $? -eq 0 ]; then
     echo "Installed Kani $VERSION successfully"
 else
     echo "::error::Could not install Kani. Please check if the provided version is correct"

--- a/src/install-kani.sh
+++ b/src/install-kani.sh
@@ -11,7 +11,7 @@ else
 fi
 
 # Check exit status for error handling
-if [ $? -eq O ]; then
+if [$? -eq O]; then
     echo "Installed Kani $VERSION successfully"
 else
     echo "::error::Could not install Kani. Please check if the provided version is correct"
@@ -24,7 +24,7 @@ cargo-kani setup;
 # Get the current installed version of kani and check it against the latest version
 installed_version=$(kani --version | awk '{print $2}')
 
-if [ $? -eq 0 ]; then
+if [$? -eq 0]; then
     if [ "$1" == "latest" ]; then
         # Cargo search returns version number as string
         requested_version=$(cargo search kani-verifier | grep -m 1 "^kani-verifier " | awk '{print $3}')


### PR DESCRIPTION
### Description of changes: 

This PR updates the action to add the parameter for `kani-version` which defaults to the value latest.
The default value latest uses the latest version of `Kani` that is uploaded on `crates.io` unless a specific version is provided by the user, in which case that specific version of `Kani` will be used in the CI.

Documentation changes [rendered here.](https://github.com/jaisnan/kani-github-action/tree/use-kani-latest-by-default)

The changes were tested in a local setting and a test project here:

1. Test for [using "latest" by default](https://github.com/jaisnan/test-vscode-extension/actions/runs/6101293421/job/16559528415). Related kani-github-action job [here](https://github.com/jaisnan/test-vscode-extension/blob/f0afa13b4542157d27c2aae9cc5a93a5e0dca4a2/.github/workflows/ci.yaml).
2. Test for [using pinned kani version](https://github.com/jaisnan/test-vscode-extension/actions/runs/6102054828/job/16559681373?pr=2). Related kani-github-action job [here](https://github.com/jaisnan/test-vscode-extension/blob/2e04619cd75bb2692cbdccba791144a000aafd65/.github/workflows/ci.yaml). 

Resolves: https://github.com/model-checking/kani-github-action/issues/46

### Call-outs:

This would update the action to pull in the latest version by default. Users who don't provide a value for the kani-version parameter would have to set it to pin the `kani` version that they want to use.

### Testing:

* How is this change tested? Tested locally, Added a CI check for the `kani-version` parameter, and ran the feature branch of the action on a test github project.

Test for [using "latest" by default](https://github.com/jaisnan/test-vscode-extension/actions/runs/6101293421/job/16559528415). Related kani-action [here](https://github.com/jaisnan/test-vscode-extension/blob/f0afa13b4542157d27c2aae9cc5a93a5e0dca4a2/.github/workflows/ci.yaml).
Test for [using pinned kani version](https://github.com/jaisnan/test-vscode-extension/actions/runs/6102054828/job/16559681373?pr=2). Related kani-action [here](https://github.com/jaisnan/test-vscode-extension/blob/2e04619cd75bb2692cbdccba791144a000aafd65/.github/workflows/ci.yaml). 

* Is this a refactor change? No

### Checklist
- [x] Each commit message has a non-empty body, explaining why the change was made
- [ ] Methods or procedures are documented
- [ ] Regression or unit tests are included, or existing tests cover the modified code
- [x] My PR is restricted to a single feature or bugfix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
