### PR TITLE
Add notice to README on main

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,27 @@
 
 This repository provides a GitHub Action for running the [Kani Rust Verifier](https://github.com/model-checking/kani) in CI.
 
+⚠️ **Important Notice**: We will soon be moving the default branch from `main` to [`v1`](https://github.com/model-checking/kani-github-action/releases/tag/v1.0).
+Please be aware that version `0.38` will be the final release on the `main` branch before the transition to stable.
+Make sure to update your workflows and references accordingly.
+We have added a new field called `kani-version` that will default to installing the latest version of `kani`.
+To install a specific version of 'kani', please add a semver version to the field `kani-version` as shown in the example below.
+
+Example:
+
+```
+jobs:
+  kani:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run Kani
+        uses: model-checking/kani-github-action@v1.0
+        with:
+          kani-version: '0.35.0'
+          command: 'cargo-kani'
+          working-directory: './path/to/project'
+```
+
 ## Security
 
 See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.
@@ -10,4 +31,3 @@ See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more inform
 
 This code is distributed under the terms of both the MIT license and the Apache License (Version 2.0).
 See [LICENSE-APACHE](LICENSE-APACHE) and [LICENSE-MIT](LICENSE-MIT) for details.
-

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 This repository provides a GitHub Action for running the [Kani Rust Verifier](https://github.com/model-checking/kani) in CI.
 
-⚠️ **Important Notice**: We will be moving to [`v1`](https://github.com/model-checking/kani-github-action/releases/tag/v1.0), which will install the latest version of `Kani` by default.
-Please be aware that version `0.38` will be the final release where the version of `Kani` matches the version of `Kani Github Action`.
+⚠️ **Important Notice**: We will be moving to [`v1`](https://github.com/model-checking/kani-github-action/releases/tag/v1.0), which will install the latest version of Kani by default.
+Please be aware that version `0.38` will be the final release where the version of Kani matches the version of Kani Github Action.
 Make sure to update your workflows and references accordingly.
-To install a specific version of `Kani`, please add a semver version to the field `kani-version` as shown in the example below.
+To install a specific version of Kani, please add a semver version to the field `kani-version` as shown in the example below.
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repository provides a GitHub Action for running the [Kani Rust Verifier](https://github.com/model-checking/kani) in CI.
 
 ⚠️ **Important Notice**: We will soon be moving the default branch from `main` to [`v1`](https://github.com/model-checking/kani-github-action/releases/tag/v1.0).
-Please be aware that version `0.38` will be the final release on the `main` branch before the transition to stable.
+Please be aware that version `0.38` will be the final release on the `main` branch before the transition to `v1`.
 Make sure to update your workflows and references accordingly.
 We have added a new field called `kani-version` that will default to installing the latest version of `kani`.
 To install a specific version of 'kani', please add a semver version to the field `kani-version` as shown in the example below.
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run Kani
-        uses: model-checking/kani-github-action@v1.0
+        uses: model-checking/kani-github-action@v1
         with:
           kani-version: '0.35.0'
           command: 'cargo-kani'

--- a/README.md
+++ b/README.md
@@ -2,11 +2,10 @@
 
 This repository provides a GitHub Action for running the [Kani Rust Verifier](https://github.com/model-checking/kani) in CI.
 
-⚠️ **Important Notice**: We will soon be moving the default branch from `main` to [`v1`](https://github.com/model-checking/kani-github-action/releases/tag/v1.0).
-Please be aware that version `0.38` will be the final release on the `main` branch before the transition to `v1`.
+⚠️ **Important Notice**: We will be moving to [`v1`](https://github.com/model-checking/kani-github-action/releases/tag/v1.0), which will install the latest version of `Kani` by default.
+Please be aware that version `0.38` will be the final release where the version of `Kani` matches the version of `Kani Github Action`.
 Make sure to update your workflows and references accordingly.
-We have added a new field called `kani-version` that will default to installing the latest version of `kani`.
-To install a specific version of 'kani', please add a semver version to the field `kani-version` as shown in the example below.
+To install a specific version of `Kani`, please add a semver version to the field `kani-version` as shown in the example below.
 
 Example:
 


### PR DESCRIPTION
### Description of changes: 

Adds notice about the move to v1, to the README on branch `main`.

Rendered version here: https://github.com/jaisnan/kani-github-action/tree/Add-notice-to-readme-main