### PR TITLE
Use stable version to install Kani

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -37,7 +37,7 @@ runs:
       shell: bash
       run: |
         export KANI_VERSION="0.38.0";
-        cargo install --version $KANI_VERSION --locked kani-verifier;
+        cargo +stable install --version $KANI_VERSION --locked kani-verifier;
         cargo-kani setup;
 
     - name: Send warning about move to v1


### PR DESCRIPTION
### Description of changes: 

The action currently uses `cargo install ...` to install Kani. If the command is issued from a path that has a `rust-toolchain` file, this results in `cargo` using the version specified in the toolchain file to install Kani. However, we should always use stable, as the toolchain version could be too old, which would cause the installation to fail, e.g.

https://github.com/aws/s2n-quic/actions/runs/7467601009/job/20322602354?pr=2085#step:3:292

### Resolved issues:

### Related RFC:

<!--
Link to the Tracking RFC issue if this work implements part of an RFC.
-->
Optional #ISSUE-NUMBER.

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
