### PR TITLE
Use stable version to install Kani

### DIFF
--- a/src/install-kani.sh
+++ b/src/install-kani.sh
@@ -4,10 +4,10 @@
 
 # If version is latest, install directly from cargo
 if [ "$1" == "latest" ]; then
-    cargo install --locked kani-verifier;
+    cargo +stable install --locked kani-verifier;
 else
     VERSION=$1
-    cargo install --version $VERSION --locked kani-verifier;
+    cargo +stable install --version $VERSION --locked kani-verifier;
 fi
 
 # Check exit status for error handling


### PR DESCRIPTION
### Description of changes: 

The action currently uses `cargo install ...` to install Kani. If the command is issued from a path that has a `rust-toolchain` file, this results in `cargo` using the version specified in the toolchain file to install Kani. However, we should always use stable, as the toolchain version could be too old, which would cause the installation to fail, e.g.

https://github.com/aws/s2n-quic/actions/runs/7467601009/job/20322602354?pr=2085#step:3:292

### Resolved issues:

### Related RFC:

<!--
Link to the Tracking RFC issue if this work implements part of an RFC.
-->
Optional #ISSUE-NUMBER.

### Call-outs:

<!-- 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
-->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
