### PR TITLE
Update README to use v1 instead of v1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run Kani
-        uses: model-checking/kani-github-action@v1.0
+        uses: model-checking/kani-github-action@v1
 ```
 
 #### Example 2: Use pinned version of Kani
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run Kani
-        uses: model-checking/kani-github-action@v1.0
+        uses: model-checking/kani-github-action@v1
         with:
           kani-version: '0.35.0'
           command: 'cargo-kani'
@@ -83,7 +83,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run Kani
-        uses: model-checking/kani-github-action@v1.0
+        uses: model-checking/kani-github-action@v1
         with:
           args: '--tests'
           enable-propproof: true


### PR DESCRIPTION
### Description of changes: 

Use v1 in our examples.

### Call-outs:

We might want to do development using `v1_dev` or some other branch, and only merge things to v1 once we are ready to release.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
